### PR TITLE
Add BidPlaced and AuctionEnded structs with relevant fields and abili…

### DIFF
--- a/contracts/auct/sources/auct.move
+++ b/contracts/auct/sources/auct.move
@@ -61,40 +61,22 @@ module auct::auction_house {
         bidder_info: String,
     }
 
+    // Represents an event when a bid is placed in an auction.
+    // Contains details such as the auction ID, bidder's address, bid amount, and timestamp.
+    public struct BidPlaced has drop, copy {
+        auction_id: object::ID,
+        bidder: address,
+        bid_amount: u64,
+        timestamp: u64,
+    }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    // Represents an event when an auction ends.
+    // Contains details such as the auction ID, winner's address, winning bid amount, and total number of bids.
+    public struct AuctionEnded has drop, copy {
+        auction_id: object::ID,
+        winner: address,
+        winning_bid: u64,
+        total_bids: u64,
+    }
 
 }


### PR DESCRIPTION
This pull request adds two new structs to the auction_house module:

BidPlaced: Represents an event when a bid is placed, including auction ID, bidder's address, bid amount, and timestamp.
AuctionEnded: Represents an event when an auction ends, including auction ID, winner's address, winning bid, and total bids.